### PR TITLE
Enhancement: Rename default config from `/.mbsyncrc` to `/mbsyncrc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,20 @@ See the following `docker-compose` examples:
 - [Demo sync](docs/examples/demo)
 
 ```sh
-# Print command line usage
-docker run --rm -it theohbrothers/docker-isync:1.4.4 --help
-
 # Create a mbsync config of your IMAP and Maildir settings
 # See: https://isync.sourceforge.io/mbsync.html#CONFIGURATION
 # See: https://wiki.archlinux.org/title/Isync
 # See real-life examples in bug reports: https://sourceforge.net/p/isync/bugs/
-touch .mbsyncrc
-vi .mbsyncrc
+touch mbsyncrc
+vi mbsyncrc
 
 # Sync
 docker run --rm -it \
-    -v $(pwd)/.mbsyncrc:/.mbsyncrc \
+    -v $(pwd)/mbsyncrc:/mbsyncrc \
     -v mail:/mail \
     theohbrothers/docker-isync:1.4.4
 
-# Help
+# Print command line usage
 docker run --rm -it theohbrothers/docker-isync:1.4.4 --help
 ```
 

--- a/docs/examples/cron/README.md
+++ b/docs/examples/cron/README.md
@@ -10,14 +10,14 @@ docker-compose up
 
 At entrypoint:
 
-- `/.mbsyncrc` is created for account `test@example.com`
+- `/mbsyncrc` is created for account `test@example.com`
 - A crontab is created that runs `mbsync` daily at `00:00`
 - `crond` is started
 
-View `/.mbsyncrc` config:
+View `/mbsyncrc` config:
 
 ```sh
-docker-compose exec isync cat /.mbsyncrc
+docker-compose exec isync cat /mbsyncrc
 ```
 
 To run the first-time sync:

--- a/docs/examples/cron/docker-compose.yml
+++ b/docs/examples/cron/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       - |
           set -eu
 
-          echo "Creating /.mbsyncrc"
-          cat - > /.mbsyncrc <<'EOF'
+          echo "Creating /mbsyncrc"
+          cat - > /mbsyncrc <<'EOF'
           # See: https://isync.sourceforge.io/mbsync.html#CONFIGURATION
           # See: https://wiki.archlinux.org/title/Isync
           # See real-life examples in bug reports: https://sourceforge.net/p/isync/bugs/
@@ -30,7 +30,7 @@ services:
 
           MaildirStore example-local
           SubFolders Verbatim
-          # The trailing '/' is important
+          # The trailing '/' is important for Path
           Path /mail/
           Inbox /mail/INBOX
 

--- a/docs/examples/demo/README.md
+++ b/docs/examples/demo/README.md
@@ -81,12 +81,12 @@ docker-compose exec isync cat /imap.example.com.pem
 docker-compose exec isync cat /imap.example.com.pem | openssl x509 -text
 ```
 
-`/.mbsyncrc` shoud have been created.
+`/mbsyncrc` shoud have been created.
 
-View `/.mbsyncrc` config:
+View `/mbsyncrc` config:
 
 ```sh
-docker-compose exec isync cat /.mbsyncrc
+docker-compose exec isync cat /mbsyncrc
 ```
 
 Now, run the sync (should take only 1 second):

--- a/docs/examples/demo/docker-compose.yml
+++ b/docs/examples/demo/docker-compose.yml
@@ -99,8 +99,8 @@ services:
           echo "Get self-signed certificate"
           mbsync-get-cert imap.example.com > /imap.example.com.pem
 
-          echo "Creating /.mbsyncrc"
-          cat - > /.mbsyncrc <<'EOF'
+          echo "Creating /mbsyncrc"
+          cat - > /mbsyncrc <<'EOF'
           # See: https://isync.sourceforge.io/mbsync.html#CONFIGURATION
           # See: https://wiki.archlinux.org/title/Isync
           # See real-life examples in bug reports: https://sourceforge.net/p/isync/bugs/
@@ -117,7 +117,7 @@ services:
 
           MaildirStore example-local
           SubFolders Verbatim
-          # The trailing '/' is important
+          # The trailing '/' is important for Path
           Path /mail/
           Inbox /mail/INBOX
 

--- a/generate/templates/README.md.ps1
+++ b/generate/templates/README.md.ps1
@@ -42,23 +42,20 @@ See the following ``docker-compose`` examples:
 - [Demo sync](docs/examples/demo)
 
 ``````sh
-# Print command line usage
-docker run --rm -it theohbrothers/docker-isync:$( $VARIANTS | ? { $_['tag_as_latest'] } | % { $_['tag'] } ) --help
-
 # Create a mbsync config of your IMAP and Maildir settings
 # See: https://isync.sourceforge.io/mbsync.html#CONFIGURATION
 # See: https://wiki.archlinux.org/title/Isync
 # See real-life examples in bug reports: https://sourceforge.net/p/isync/bugs/
-touch .mbsyncrc
-vi .mbsyncrc
+touch mbsyncrc
+vi mbsyncrc
 
 # Sync
 docker run --rm -it \
-    -v `$(pwd)/.mbsyncrc:/.mbsyncrc \
+    -v `$(pwd)/mbsyncrc:/mbsyncrc \
     -v mail:/mail \
     theohbrothers/docker-isync:$( $VARIANTS | ? { $_['tag_as_latest'] } | % { $_['tag'] } )
 
-# Help
+# Print command line usage
 docker run --rm -it theohbrothers/docker-isync:$( $VARIANTS | ? { $_['tag_as_latest'] } | % { $_['tag'] } ) --help
 ``````
 

--- a/generate/templates/sync.ps1
+++ b/generate/templates/sync.ps1
@@ -2,6 +2,6 @@
 #!/bin/sh
 set -eu
 
-mbsync --config /.mbsyncrc --all --verbose
+mbsync --config /mbsyncrc --all --verbose
 
 '@

--- a/variants/1.4.4/sync
+++ b/variants/1.4.4/sync
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-mbsync --config /.mbsyncrc --all --verbose
+mbsync --config /mbsyncrc --all --verbose


### PR DESCRIPTION
This is for better visibility when using `ls` as a config file in contrast to a dotfile.
